### PR TITLE
Fix IntelliJ not seeing generated entities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val codegen = project.settings(
 
 lazy val app = project.settings(
   sourceGenerators in Compile += Def.taskDyn {
-    val outFile = sourceManaged.value / "mycodegen" / "Generated.scala"
+    val outFile = sourceManaged.in(Compile).value / "mycodegen" / "Generated.scala"
     Def.task {
       (run in codegen in Compile)
         .toTask(" " + outFile.getAbsolutePath)


### PR DESCRIPTION
Hi Olafur!

First, thank you for this blueprint which got me started writing a generator in our own SBT project! Here's just a small fix which I thought I'd share.

I usually fixed this problem manually by marking `target/scala_2.1?/src_managed` as a "Generated Sources Root" directory, but by changing the scope it works out of the box.